### PR TITLE
Composer: update PHP Parallel Lint dependency version restraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3",
-        "php-parallel-lint/php-parallel-lint": "1.0",
+        "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
         "squizlabs/php_codesniffer": "1.*",
         "php-parallel-lint/php-code-style": "1.0"


### PR DESCRIPTION
The PHP Parallel Lint dependency was fixed at version `1.0`, not allowing 1.* versions to be installed.