### PR TITLE
Update the unit tests setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,4 @@
 .gitignore export-ignore
 .travis.yml export-ignore
 build.xml export-ignore
-phpunit.xml export-ignore
+phpunit.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build
 vendor
 composer.lock
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,13 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - composer install --no-interaction --prefer-source
+  - |
+    if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+      composer install --no-suggest --no-interaction
+    else
+      # Ignore platform requirements to allow PHPUnit to install on PHP 8.
+      composer install --no-suggest --no-interaction --ignore-platform-reqs
+    fi
 
 script:
   - ant phplint

--- a/build.xml
+++ b/build.xml
@@ -64,7 +64,7 @@
     <target name="phpunit" depends="prepare" description="PHP unit">
         <delete file="${basedir}/build/logs/phpunit.xml" quiet="true" />
 
-        <exec executable="${phpunit}">
+        <exec executable="${phpunit}" failonerror="true">
             <arg line='--configuration ${basedir}/phpunit.xml.dist' />
             <arg line='-d memory_limit=256M' />
             <arg line='--log-junit "${basedir}/build/logs/phpunit.xml"' />
@@ -78,7 +78,7 @@
         <delete dir="${basedir}/build/coverage" quiet="true" />
         <mkdir dir="${basedir}/build/coverage" />
 
-        <exec executable="${phpunit}">
+        <exec executable="${phpunit}" failonerror="true">
             <arg line='--configuration ${basedir}/phpunit.xml.dist' />
             <arg line='-d memory_limit=256M' />
             <arg line='--log-junit "${basedir}/build/logs/phpunit.xml"' />

--- a/build.xml
+++ b/build.xml
@@ -65,7 +65,7 @@
         <delete file="${basedir}/build/logs/phpunit.xml" quiet="true" />
 
         <exec executable="${phpunit}">
-            <arg line='--configuration ${basedir}/phpunit.xml' />
+            <arg line='--configuration ${basedir}/phpunit.xml.dist' />
             <arg line='-d memory_limit=256M' />
             <arg line='--log-junit "${basedir}/build/logs/phpunit.xml"' />
             <arg line='${colors-arg.color}' />
@@ -79,7 +79,7 @@
         <mkdir dir="${basedir}/build/coverage" />
 
         <exec executable="${phpunit}">
-            <arg line='--configuration ${basedir}/phpunit.xml' />
+            <arg line='--configuration ${basedir}/phpunit.xml.dist' />
             <arg line='-d memory_limit=256M' />
             <arg line='--log-junit "${basedir}/build/logs/phpunit.xml"' />
             <arg line='--coverage-clover "${basedir}/build/logs/clover.xml"' />

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.3",
+        "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
         "squizlabs/php_codesniffer": "1.*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    backupGlobals="true"
     bootstrap="./vendor/autoload.php">
+
     <testsuites>
-        <testsuite>
+        <testsuite name="PHP-Console-Color">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
 
-    <!-- Ignore vendor folder for code coverage -->
     <filter>
-        <blacklist>
-            <directory>vendor</directory>
-        </blacklist>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
     </filter>
 </phpunit>

--- a/tests/ConsoleColorTest.php
+++ b/tests/ConsoleColorTest.php
@@ -41,13 +41,13 @@ class ConsoleColorTest extends \PHPUnit_Framework_TestCase
     public function testNone()
     {
         $output = $this->uut->apply('none', 'text');
-        $this->assertEquals("text", $output);
+        $this->assertSame("text", $output);
     }
 
     public function testBold()
     {
         $output = $this->uut->apply('bold', 'text');
-        $this->assertEquals("\033[1mtext\033[0m", $output);
+        $this->assertSame("\033[1mtext\033[0m", $output);
     }
 
     public function testBoldColorsAreNotSupported()
@@ -55,7 +55,7 @@ class ConsoleColorTest extends \PHPUnit_Framework_TestCase
         $this->uut->setIsSupported(false);
 
         $output = $this->uut->apply('bold', 'text');
-        $this->assertEquals("text", $output);
+        $this->assertSame("text", $output);
     }
 
     public function testBoldColorsAreNotSupportedButAreForced()
@@ -64,25 +64,25 @@ class ConsoleColorTest extends \PHPUnit_Framework_TestCase
         $this->uut->setForceStyle(true);
 
         $output = $this->uut->apply('bold', 'text');
-        $this->assertEquals("\033[1mtext\033[0m", $output);
+        $this->assertSame("\033[1mtext\033[0m", $output);
     }
 
     public function testDark()
     {
         $output = $this->uut->apply('dark', 'text');
-        $this->assertEquals("\033[2mtext\033[0m", $output);
+        $this->assertSame("\033[2mtext\033[0m", $output);
     }
 
     public function testBoldAndDark()
     {
         $output = $this->uut->apply(array('bold', 'dark'), 'text');
-        $this->assertEquals("\033[1;2mtext\033[0m", $output);
+        $this->assertSame("\033[1;2mtext\033[0m", $output);
     }
 
     public function test256ColorForeground()
     {
         $output = $this->uut->apply('color_255', 'text');
-        $this->assertEquals("\033[38;5;255mtext\033[0m", $output);
+        $this->assertSame("\033[38;5;255mtext\033[0m", $output);
     }
 
     public function test256ColorWithoutSupport()
@@ -90,47 +90,47 @@ class ConsoleColorTest extends \PHPUnit_Framework_TestCase
         $this->uut->setAre256ColorsSupported(false);
 
         $output = $this->uut->apply('color_255', 'text');
-        $this->assertEquals("text", $output);
+        $this->assertSame("text", $output);
     }
 
     public function test256ColorBackground()
     {
         $output = $this->uut->apply('bg_color_255', 'text');
-        $this->assertEquals("\033[48;5;255mtext\033[0m", $output);
+        $this->assertSame("\033[48;5;255mtext\033[0m", $output);
     }
 
     public function test256ColorForegroundAndBackground()
     {
         $output = $this->uut->apply(array('color_200', 'bg_color_255'), 'text');
-        $this->assertEquals("\033[38;5;200;48;5;255mtext\033[0m", $output);
+        $this->assertSame("\033[38;5;200;48;5;255mtext\033[0m", $output);
     }
 
     public function testSetOwnTheme()
     {
         $this->uut->setThemes(array('bold_dark' => array('bold', 'dark')));
         $output = $this->uut->apply(array('bold_dark'), 'text');
-        $this->assertEquals("\033[1;2mtext\033[0m", $output);
+        $this->assertSame("\033[1;2mtext\033[0m", $output);
     }
 
     public function testAddOwnTheme()
     {
         $this->uut->addTheme('bold_own', 'bold');
         $output = $this->uut->apply(array('bold_own'), 'text');
-        $this->assertEquals("\033[1mtext\033[0m", $output);
+        $this->assertSame("\033[1mtext\033[0m", $output);
     }
 
     public function testAddOwnThemeArray()
     {
         $this->uut->addTheme('bold_dark', array('bold', 'dark'));
         $output = $this->uut->apply(array('bold_dark'), 'text');
-        $this->assertEquals("\033[1;2mtext\033[0m", $output);
+        $this->assertSame("\033[1;2mtext\033[0m", $output);
     }
 
     public function testOwnWithStyle()
     {
         $this->uut->addTheme('bold_dark', array('bold', 'dark'));
         $output = $this->uut->apply(array('bold_dark', 'italic'), 'text');
-        $this->assertEquals("\033[1;2;3mtext\033[0m", $output);
+        $this->assertSame("\033[1;2;3mtext\033[0m", $output);
     }
 
     public function testHasAndRemoveTheme()

--- a/tests/ConsoleColorTest.php
+++ b/tests/ConsoleColorTest.php
@@ -1,5 +1,6 @@
 <?php
 use JakubOnderka\PhpConsoleColor\ConsoleColor;
+use PHPUnit\Framework\TestCase;
 
 class ConsoleColorWithForceSupport extends ConsoleColor
 {
@@ -28,7 +29,7 @@ class ConsoleColorWithForceSupport extends ConsoleColor
     }
 }
 
-class ConsoleColorTest extends \PHPUnit_Framework_TestCase
+class ConsoleColorTest extends TestCase
 {
     /** @var ConsoleColorWithForceSupport */
     private $uut;
@@ -146,25 +147,25 @@ class ConsoleColorTest extends \PHPUnit_Framework_TestCase
 
     public function testApplyInvalidArgument()
     {
-        $this->setExpectedException('\InvalidArgumentException');
+        $this->exceptionHelper('\InvalidArgumentException');
         $this->uut->apply(new stdClass(), 'text');
     }
 
     public function testApplyInvalidStyleName()
     {
-        $this->setExpectedException('\JakubOnderka\PhpConsoleColor\InvalidStyleException');
+        $this->exceptionHelper('\JakubOnderka\PhpConsoleColor\InvalidStyleException');
         $this->uut->apply('invalid', 'text');
     }
 
     public function testApplyInvalid256Color()
     {
-        $this->setExpectedException('\JakubOnderka\PhpConsoleColor\InvalidStyleException');
+        $this->exceptionHelper('\JakubOnderka\PhpConsoleColor\InvalidStyleException');
         $this->uut->apply('color_2134', 'text');
     }
 
     public function testThemeInvalidStyle()
     {
-        $this->setExpectedException('\JakubOnderka\PhpConsoleColor\InvalidStyleException');
+        $this->exceptionHelper('\JakubOnderka\PhpConsoleColor\InvalidStyleException');
         $this->uut->addTheme('invalid', array('invalid'));
     }
 
@@ -179,6 +180,24 @@ class ConsoleColorTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInternalType('array', $this->uut->getPossibleStyles());
         $this->assertNotEmpty($this->uut->getPossibleStyles());
+    }
+
+    public function exceptionHelper($exception, $msg = null)
+    {
+        if (\method_exists($this, 'expectException')) {
+            // PHPUnit 5+.
+            $this->expectException($exception);
+            if (isset($msg)) {
+                $this->expectExceptionMessage($msg);
+            }
+        } else {
+            // PHPUnit 4.
+            if (isset($msg)) {
+                $this->setExpectedException($exception, $msg);
+            } else {
+                $this->setExpectedException($exception);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
As can be seen in the build against [`nightly` on the latest `master`](https://travis-ci.org/github/php-parallel-lint/PHP-Console-Color/jobs/713261668#L240-L258), the unit tests fail to run on PHP 8 at this moment, which makes ensuring compatibility with the upcoming PHP 8.0 release hard.

This PR updates the PHPUnit setup to allow the tests to be compatible with a wider range of PHPUnit versions, which will then allow them to run on PHP 8.0, even though they would still use an unsupported PHPUnit version (official PHPUnit support for PHP 8 is expected in the upcoming 9.3 release).

It also sets up the unit tests to actually fail the build if they don't pass and implements some stricter testing.

If you examine the build logs on Travis for this PR, you will see that the tests will now actually run against PHP `nightly` and pass.

## Commit Details

### PHPUnit setup: rename and update the config file

It is recommended to use the `phpunit.xml.dist` file name for the PHPUnit configuration file to allow individual developers to overload it with a `phpunit.xml` file.

To this end, I've:
* Renamed the PHPUnit configuration file.
* Adjusted the corresponding `export-ignore` in `.gitattributes`.
* Added `phpunit.xml` to the `.gitignore` file so overload files from individual developers do not get committed.
* Adjusted the references to the file in the Ant `build.xml` file.

As for the config file itself:
* Added a name for the testsuite as is required in later PHPUnit versions.
* Changed the coverage `filter` directive to be more precise.
* Added an explicit `backupGlobals` setting as the default value has changed across PHPUnit versions.

### PHPUnit: use a type-safe assertion

`assertEquals()` is to `assertSame()` as `==` is to `===`, so always use `assertSame()` unless you _need_ a loose comparison.

### PHPUnit: widen the version requirements

Made the unit tests compatible with PHPUnit 4.x - 7.x.

### Travis: allow for installing PHPUnit 7 on PHP 8

### Ant: fail the build on unit test failures 