### PR TITLE
Composer: add description

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "php-parallel-lint/php-console-color",
+    "description": "Simple library for creating colored console ouput.",
     "license": "BSD-2-Clause",
     "authors": [
         {


### PR DESCRIPTION
When running `composer validate`, a warning was shown:
```
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required
```

Adding a description fixes this.