### PR TITLE
Travis: add build against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.0
   - "nightly"
 
 jobs:
@@ -34,7 +35,7 @@ cache:
 
 before_script:
   - |
-    if [[ $TRAVIS_PHP_VERSION != "nightly" ]]; then
+    if [[ $TRAVIS_PHP_VERSION != "nightly" && $TRAVIS_PHP_VERSION != "8.0" ]]; then
       composer install --no-suggest --no-interaction
     else
       # Ignore platform requirements to allow PHPUnit to install on PHP 8.


### PR DESCRIPTION
PHP 8.0 has been branched off two months ago, so `nightly` is now PHP 8.1 and in the mean time PHP 8.0 was released last week.

As of today, there is a PHP 8.0 image available on Travis.

This PR adds a new build against PHP 8.0 to the matrix and, as PHP 8.0 has been released, that build is not allowed to fail.