### PR TITLE
PHPCS: various improvements

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 .travis.yml export-ignore
 build.xml export-ignore
 phpunit.xml.dist export-ignore
+phpcs.xml.dist export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 vendor
 composer.lock
 phpunit.xml
+.phpcs.xml
+phpcs.xml

--- a/build.xml
+++ b/build.xml
@@ -52,12 +52,10 @@
     <target name="phpcs" depends="prepare" description="Check PHP code style">
         <delete file="${basedir}/build/logs/checkstyle.xml" quiet="true" />
 
-        <exec executable="${phpcs}">
-            <arg line='--extensions=php' />
-            <arg line='--standard="${basedir}/vendor/php-parallel-lint/php-code-style/ruleset.xml"' />
+        <exec executable="${phpcs}" failonerror="true">
             <arg line='--report-checkstyle="${basedir}/build/logs/checkstyle.xml"' />
             <arg line='--report-full' />
-            <arg line='"${basedir}/src"' />
+            <arg line='--runtime-set ignore_warnings_on_exit 1' />
         </exec>
     </target>
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
-        "squizlabs/php_codesniffer": "1.*",
+        "squizlabs/php_codesniffer": "3.*",
         "php-parallel-lint/php-code-style": "1.0"
     },
     "replace": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<ruleset name="Jakub Onderka Coding Standard">
+    <description>A coding standard for Jakub Onderka's projects.</description>
+
+    <file>./src/</file>
+
+    <!-- Only check PHP files. -->
+    <arg name="extensions" value="php"/>
+
+    <!-- Show progress, show the error codes for each message (source). -->
+    <arg value="ps"/>
+
+    <!-- Strip the filepaths down to the relevant bit. -->
+    <arg name="basepath" value="./"/>
+
+    <rule ref="./vendor/php-parallel-lint/php-code-style/ruleset.xml"/>
+
+</ruleset>


### PR DESCRIPTION
* Composer: update the PHPCS version used to PHPCS 3.5.0+.
* PHPCS: add a PHPCS configuration file containing all the common command-line parameters.
    This file will be automatically picked up by PHPCS and can be overruled locally by a `[.]phpcs.xml` file.
* Ant: remove the configuration CLI arguments which are now contained in the `phpcs.xml.dist` file from the `build.xml` task configuration.
* Ant: add a CLI argument which will ignore CS warnings when determining the exit code, but will still _show_ warnings in the report.
    Using this will also allow for enabling `failonerror` for the build step.
* Git: Add the `phpcs.xml.dist` file to the `.gitattributes` file to be ignored when packaging a release.
* Git: Add the potential local overload files to the `.gitignore` file.