### PR TITLE
PHPUnit: improve configuration

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -65,9 +65,7 @@
         <delete file="${basedir}/build/logs/phpunit.xml" quiet="true" />
 
         <exec executable="${phpunit}" failonerror="true">
-            <arg line='--configuration ${basedir}/phpunit.xml.dist' />
-            <arg line='-d memory_limit=256M' />
-            <arg line='--log-junit "${basedir}/build/logs/phpunit.xml"' />
+            <arg line='--no-coverage' />
             <arg line='${colors-arg.color}' />
         </exec>
     </target>
@@ -79,11 +77,6 @@
         <mkdir dir="${basedir}/build/coverage" />
 
         <exec executable="${phpunit}" failonerror="true">
-            <arg line='--configuration ${basedir}/phpunit.xml.dist' />
-            <arg line='-d memory_limit=256M' />
-            <arg line='--log-junit "${basedir}/build/logs/phpunit.xml"' />
-            <arg line='--coverage-clover "${basedir}/build/logs/clover.xml"' />
-            <arg line='--coverage-html "${basedir}/build/coverage/"' />
             <arg line='${colors-arg.color}' />
         </exec>
     </target>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,4 +14,14 @@
             <directory suffix=".php">src</directory>
         </whitelist>
     </filter>
+
+    <logging>
+        <log type="junit" target="build/logs/phpunit.xml"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <log type="coverage-html" target="build/coverage/"/>
+    </logging>
+
+    <php>
+        <ini name="memory_limit" value="256M"/>
+    </php>
 </phpunit>


### PR DESCRIPTION
Move the CLI arguments which can be placed in the configuration file to the configuration file and removed them from the Ant build configuration.