### PR TITLE
PHPUnit: use annotations for fixtures / cross-version compat up to PHPUnit 9.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ build
 vendor
 composer.lock
 phpunit.xml
+.phpunit.result.cache
 .phpcs.xml
 phpcs.xml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
         "squizlabs/php_codesniffer": "3.*",

--- a/tests/ConsoleColorTest.php
+++ b/tests/ConsoleColorTest.php
@@ -36,7 +36,10 @@ class ConsoleColorTest extends TestCase
     /** @var ConsoleColorWithForceSupport */
     private $uut;
 
-    protected function setUp()
+    /**
+     * @before
+     */
+    protected function setUpConsoleColor()
     {
         $this->uut = new ConsoleColorWithForceSupport();
     }
@@ -180,7 +183,13 @@ class ConsoleColorTest extends TestCase
 
     public function testGetPossibleStyles()
     {
-        $this->assertInternalType('array', $this->uut->getPossibleStyles());
+        if (\method_exists($this, 'assertIsArray')) {
+            // PHPUnit 7.5+.
+            $this->assertIsArray($this->uut->getPossibleStyles());
+        } else {
+            // PHPUnit < 7.5.
+            $this->assertInternalType('array', $this->uut->getPossibleStyles());
+        }
         $this->assertNotEmpty($this->uut->getPossibleStyles());
     }
 


### PR DESCRIPTION
As of PHPUnit 8.x, the method signature for the `setUpBeforeClass()`, `setUp()`, `tearDown()` and `tearDownAfterClass()` fixture methods has changed to require the `void` return type.

As the `void` return type isn't available until PHP 7.1, this cannot be implemented.

Annotations to the rescue.
By renaming the `setUp()` method to another, descriptive name and using the `@before` annotation, the tests can be made cross-version compatible up to PHPUnit 9.x.

With this change, the unit tests can now be run on PHPUnit 4 - 9.

As PHPUnit has a caching feature build in as of PHPUnit 8, we need to add the `.phpunit.result.cache` file to `.gitignore`.

There is also one assertion which has changed, so using an if/else to work around that.