### PR TITLE
Bring back support for PHP 5.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
         experimental: [false]
 
         include:
@@ -39,6 +39,11 @@ jobs:
           ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
           coverage: none
           tools: cs2pr
+
+      # Remove PHPCS as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.
+      - name: 'Composer: remove PHPCS'
+        if: ${{ matrix.php < 5.4 }}
+        run: composer remove --dev squizlabs/php_codesniffer --no-update
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "psr-4": {"PHP_Parallel_Lint\\PhpConsoleColor\\Test\\": "tests/"}
     },
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",


### PR DESCRIPTION
As Parallel Lint supports PHP 5.3 again since [PR 51](https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/51), it would be helpful for the Console Color repo to also support PHP 5.3.

This restores the PHP 5.3 minimum version to the same as before the version drop in de0bf63387e39b04394e9b8f2257c62d16ad57a7