### PR TITLE
Tests: one class per file

### DIFF
--- a/tests/ConsoleColorTest.php
+++ b/tests/ConsoleColorTest.php
@@ -2,34 +2,8 @@
 namespace PHP_Parallel_Lint\PhpConsoleColor\Test;
 
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
+use PHP_Parallel_Lint\PhpConsoleColor\Test\Fixtures\ConsoleColorWithForceSupport;
 use PHPUnit\Framework\TestCase;
-
-class ConsoleColorWithForceSupport extends ConsoleColor
-{
-    private $isSupportedForce = true;
-
-    private $are256ColorsSupportedForce = true;
-
-    public function setIsSupported($isSupported)
-    {
-        $this->isSupportedForce = $isSupported;
-    }
-
-    public function isSupported()
-    {
-        return $this->isSupportedForce;
-    }
-
-    public function setAre256ColorsSupported($are256ColorsSupported)
-    {
-        $this->are256ColorsSupportedForce = $are256ColorsSupported;
-    }
-
-    public function are256ColorsSupported()
-    {
-        return $this->are256ColorsSupportedForce;
-    }
-}
 
 class ConsoleColorTest extends TestCase
 {

--- a/tests/Fixtures/ConsoleColorWithForceSupport.php
+++ b/tests/Fixtures/ConsoleColorWithForceSupport.php
@@ -1,0 +1,31 @@
+<?php
+namespace PHP_Parallel_Lint\PhpConsoleColor\Test\Fixtures;
+
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
+
+class ConsoleColorWithForceSupport extends ConsoleColor
+{
+    private $isSupportedForce = true;
+
+    private $are256ColorsSupportedForce = true;
+
+    public function setIsSupported($isSupported)
+    {
+        $this->isSupportedForce = $isSupported;
+    }
+
+    public function isSupported()
+    {
+        return $this->isSupportedForce;
+    }
+
+    public function setAre256ColorsSupported($are256ColorsSupported)
+    {
+        $this->are256ColorsSupportedForce = $are256ColorsSupported;
+    }
+
+    public function are256ColorsSupported()
+    {
+        return $this->are256ColorsSupportedForce;
+    }
+}


### PR DESCRIPTION
Move the `ConsoleColorWithForceSupport` fixture used in the tests to a separate file.