### PR TITLE
Improve tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": ">=5.3.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
         "squizlabs/php_codesniffer": "3.*",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    backupGlobals="true"
-    bootstrap="./vendor/autoload.php"
-    convertDeprecationsToExceptions="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.2/phpunit.xsd"
+        backupGlobals="true"
+        beStrictAboutTestsThatDoNotTestAnything="true"
+        bootstrap="./vendor/autoload.php"
+        colors="true"
+        convertDeprecationsToExceptions="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="true"
+        stopOnFailure="false"
+        verbose="true"
     >
 
     <testsuites>
@@ -18,9 +28,9 @@
     </filter>
 
     <logging>
-        <log type="junit" target="build/logs/phpunit.xml"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
         <log type="coverage-html" target="build/coverage/"/>
+        <log type="coverage-text" target="php://stdout" showOnlySummary="true"/>
     </logging>
 
     <php>

--- a/src/ConsoleColor.php
+++ b/src/ConsoleColor.php
@@ -196,6 +196,8 @@ class ConsoleColor
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @return bool
      */
     public function isSupported()
@@ -213,6 +215,8 @@ class ConsoleColor
     }
 
     /**
+     * @codeCoverageIgnore
+     *
      * @return bool
      */
     public function are256ColorsSupported()

--- a/tests/ConsoleColorTest.php
+++ b/tests/ConsoleColorTest.php
@@ -5,6 +5,10 @@ use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 use PHP_Parallel_Lint\PhpConsoleColor\Test\Fixtures\ConsoleColorWithForceSupport;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @coversDefaultClass \PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor
+ * @covers ::__construct
+ */
 class ConsoleColorTest extends TestCase
 {
     /** @var ConsoleColorWithForceSupport */
@@ -18,18 +22,28 @@ class ConsoleColorTest extends TestCase
         $this->uut = new ConsoleColorWithForceSupport();
     }
 
+    /**
+     * @covers ::apply
+     */
     public function testNone()
     {
         $output = $this->uut->apply('none', 'text');
         $this->assertSame("text", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::escSequence
+     */
     public function testBold()
     {
         $output = $this->uut->apply('bold', 'text');
         $this->assertSame("\033[1mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::apply
+     */
     public function testBoldColorsAreNotSupported()
     {
         $this->uut->setIsSupported(false);
@@ -38,6 +52,10 @@ class ConsoleColorTest extends TestCase
         $this->assertSame("text", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::setForceStyle
+     */
     public function testBoldColorsAreNotSupportedButAreForced()
     {
         $this->uut->setIsSupported(false);
@@ -47,24 +65,41 @@ class ConsoleColorTest extends TestCase
         $this->assertSame("\033[1mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::escSequence
+     */
     public function testDark()
     {
         $output = $this->uut->apply('dark', 'text');
         $this->assertSame("\033[2mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::escSequence
+     */
     public function testBoldAndDark()
     {
         $output = $this->uut->apply(array('bold', 'dark'), 'text');
         $this->assertSame("\033[1;2mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::styleSequence
+     * @covers ::escSequence
+     */
     public function test256ColorForeground()
     {
         $output = $this->uut->apply('color_255', 'text');
         $this->assertSame("\033[38;5;255mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::styleSequence
+     */
     public function test256ColorWithoutSupport()
     {
         $this->uut->setAre256ColorsSupported(false);
@@ -73,18 +108,32 @@ class ConsoleColorTest extends TestCase
         $this->assertSame("text", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::styleSequence
+     * @covers ::escSequence
+     */
     public function test256ColorBackground()
     {
         $output = $this->uut->apply('bg_color_255', 'text');
         $this->assertSame("\033[48;5;255mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::styleSequence
+     * @covers ::escSequence
+     */
     public function test256ColorForegroundAndBackground()
     {
         $output = $this->uut->apply(array('color_200', 'bg_color_255'), 'text');
         $this->assertSame("\033[38;5;200;48;5;255mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::setThemes
+     * @covers ::themeSequence
+     */
     public function testSetOwnTheme()
     {
         $this->uut->setThemes(array('bold_dark' => array('bold', 'dark')));
@@ -92,6 +141,10 @@ class ConsoleColorTest extends TestCase
         $this->assertSame("\033[1;2mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::addTheme
+     * @covers ::themeSequence
+     */
     public function testAddOwnTheme()
     {
         $this->uut->addTheme('bold_own', 'bold');
@@ -99,6 +152,11 @@ class ConsoleColorTest extends TestCase
         $this->assertSame("\033[1mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::addTheme
+     * @covers ::themeSequence
+     */
     public function testAddOwnThemeArray()
     {
         $this->uut->addTheme('bold_dark', array('bold', 'dark'));
@@ -116,6 +174,13 @@ class ConsoleColorTest extends TestCase
         $this->uut->addTheme('invalid', new \ArrayIterator(array('bold', 'dark')));
     }
 
+    /**
+     * @covers ::apply
+     * @covers ::addTheme
+     * @covers ::themeSequence
+     * @covers ::styleSequence
+     * @covers ::isValidStyle
+     */
     public function testOwnWithStyle()
     {
         $this->uut->addTheme('bold_dark', array('bold', 'dark'));
@@ -145,6 +210,10 @@ class ConsoleColorTest extends TestCase
         $this->assertCount(2, $themes);
     }
 
+    /**
+     * @covers ::hasTheme
+     * @covers ::removeTheme
+     */
     public function testHasAndRemoveTheme()
     {
         $this->assertFalse($this->uut->hasTheme('bold_dark'));
@@ -156,30 +225,50 @@ class ConsoleColorTest extends TestCase
         $this->assertFalse($this->uut->hasTheme('bold_dark'));
     }
 
+    /**
+     * @covers ::apply
+     */
     public function testApplyInvalidArgument()
     {
         $this->exceptionHelper('\InvalidArgumentException');
         $this->uut->apply(new \stdClass(), 'text');
     }
 
+    /**
+     * @covers ::apply
+     * @covers \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
+     */
     public function testApplyInvalidStyleName()
     {
         $this->exceptionHelper('\PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException');
         $this->uut->apply('invalid', 'text');
     }
 
+    /**
+     * @covers ::apply
+     * @covers \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
+     */
     public function testApplyInvalid256Color()
     {
         $this->exceptionHelper('\PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException');
         $this->uut->apply('color_2134', 'text');
     }
 
+    /**
+     * @covers ::addTheme
+     * @covers ::isValidStyle
+     * @covers \PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException
+     */
     public function testThemeInvalidStyle()
     {
         $this->exceptionHelper('\PHP_Parallel_Lint\PhpConsoleColor\InvalidStyleException');
         $this->uut->addTheme('invalid', array('invalid'));
     }
 
+    /**
+     * @covers ::setForceStyle
+     * @covers ::isStyleForced
+     */
     public function testForceStyle()
     {
         $this->assertFalse($this->uut->isStyleForced());
@@ -187,6 +276,9 @@ class ConsoleColorTest extends TestCase
         $this->assertTrue($this->uut->isStyleForced());
     }
 
+    /**
+     * @covers ::getPossibleStyles
+     */
     public function testGetPossibleStyles()
     {
         if (\method_exists($this, 'assertIsArray')) {

--- a/tests/ConsoleColorTest.php
+++ b/tests/ConsoleColorTest.php
@@ -123,6 +123,28 @@ class ConsoleColorTest extends TestCase
         $this->assertSame("\033[1;2;3mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::getThemes
+     */
+    public function testGetThemes()
+    {
+        $this->assertSame(array(), $this->uut->getThemes());
+
+        $this->uut->addTheme('bold_dark', array('bold', 'dark'));
+        $this->uut->addTheme('dark_italic', array('dark', 'italic'));
+
+        $themes = $this->uut->getThemes();
+        if (\method_exists($this, 'assertIsArray')) {
+            // PHPUnit 7.5+.
+            $this->assertIsArray($themes);
+        } else {
+            // PHPUnit < 7.5.
+            $this->assertInternalType('array', $themes);
+        }
+
+        $this->assertCount(2, $themes);
+    }
+
     public function testHasAndRemoveTheme()
     {
         $this->assertFalse($this->uut->hasTheme('bold_dark'));

--- a/tests/ConsoleColorTest.php
+++ b/tests/ConsoleColorTest.php
@@ -106,6 +106,16 @@ class ConsoleColorTest extends TestCase
         $this->assertSame("\033[1;2mtext\033[0m", $output);
     }
 
+    /**
+     * @covers ::addTheme
+     */
+    public function testAddOwnThemeInvalidInput()
+    {
+        $this->exceptionHelper('\InvalidArgumentException', 'Style must be string or array.');
+
+        $this->uut->addTheme('invalid', new \ArrayIterator(array('bold', 'dark')));
+    }
+
     public function testOwnWithStyle()
     {
         $this->uut->addTheme('bold_dark', array('bold', 'dark'));


### PR DESCRIPTION
These changes together stabilize the test suite and bring the code coverage to 100% (line/branch).

## Commit details 

### Composer: improve PHPUnit version constraints

... as PHPUnit < 5.7.21 doesn't contain the forward compatibility layer with namespaced classes.

### PHPUnit: improve configuration

* Add more detailed basic test configuration
* Unless `junit` is used somewhere, generating this report for code coverage is unnecessary.
* Generating the text report, however, is useful.

### ConsoleColor: mark two methods as untestable

These methods cannot be tested as the result is system dependent and cannot be emulated.

### ConsoleColor::addTheme(): add test for exception

### ConsoleColor::getThemes(): add perfunctory unit test

### Tests: add @covers tag

... to document what each test is testing.