### PR TITLE
Use PHP-Code-Style 2.0

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -38,4 +38,4 @@ jobs:
         run: vendor/bin/phpcs --report-full --report-checkstyle=./checkstyle.xml
 
       - name: Show PHPCS results in PR
-        run: cs2pr ./checkstyle.xml --graceful-warnings
+        run: cs2pr ./checkstyle.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,10 +40,10 @@ jobs:
           coverage: none
           tools: cs2pr
 
-      # Remove PHPCS as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.
+      # Remove the PHPCS standard as it has a minimum PHP requirements of PHP 5.4 and would block install on PHP 5.3.
       - name: 'Composer: remove PHPCS'
         if: ${{ matrix.php < 5.4 }}
-        run: composer remove --dev squizlabs/php_codesniffer --no-update
+        run: composer remove --dev php-parallel-lint/php-code-style --no-update
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,7 @@
         "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "php-parallel-lint/php-parallel-lint": "^1.0",
         "php-parallel-lint/php-var-dump-check": "0.*",
-        "squizlabs/php_codesniffer": "3.*",
-        "php-parallel-lint/php-code-style": "1.0"
+        "php-parallel-lint/php-code-style": "^2.0"
     },
     "replace": {
         "jakub-onderka/php-console-color": "*"

--- a/example.php
+++ b/example.php
@@ -1,4 +1,5 @@
 <?php
+
 $loader = require_once __DIR__ . '/vendor/autoload.php';
 
 $consoleColor = new PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor();

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,8 +1,20 @@
 <?xml version="1.0"?>
-<ruleset name="Jakub Onderka Coding Standard">
+<ruleset name="PHP-Console-Color">
     <description>A coding standard for Jakub Onderka's projects.</description>
 
-    <file>./src/</file>
+    <!--
+    #############################################################################
+    COMMAND LINE ARGUMENTS
+    https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+    #############################################################################
+    -->
+
+    <!-- Scan all files. -->
+    <file>.</file>
+
+    <!-- Exclude dependencies and auto-generated files. -->
+    <exclude-pattern>*/build/*</exclude-pattern>
+    <exclude-pattern>*/vendor/*</exclude-pattern>
 
     <!-- Only check PHP files. -->
     <arg name="extensions" value="php"/>
@@ -13,6 +25,19 @@
     <!-- Strip the filepaths down to the relevant bit. -->
     <arg name="basepath" value="./"/>
 
-    <rule ref="./vendor/php-parallel-lint/php-code-style/ruleset.xml"/>
+    <!-- Check up to 8 files simultaneously. -->
+    <arg name="parallel" value="8"/>
+
+
+    <!--
+    #############################################################################
+    USE THE PHPParallelLint RULESET
+    #############################################################################
+    -->
+
+    <!-- Set the supported PHP versions for PHPCompatibility (included in PHPParallelLint). -->
+    <config name="testVersion" value="5.3-"/>
+
+    <rule ref="PHPParallelLint"/>
 
 </ruleset>

--- a/src/ConsoleColor.php
+++ b/src/ConsoleColor.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpConsoleColor;
 
 class ConsoleColor
@@ -99,7 +100,7 @@ class ConsoleColor
         foreach ($style as $s) {
             if (isset($this->themes[$s])) {
                 $sequences = array_merge($sequences, $this->themeSequence($s));
-            } else if ($this->isValidStyle($s)) {
+            } elseif ($this->isValidStyle($s)) {
                 $sequences[] = $this->styleSequence($s);
             } else {
                 throw new InvalidStyleException($s);
@@ -203,6 +204,7 @@ class ConsoleColor
     public function isSupported()
     {
         if (DIRECTORY_SEPARATOR === '\\') {
+            // phpcs:ignore Generic.PHP.NoSilencedErrors,PHPCompatibility.FunctionUse.NewFunctions.sapi_windows_vt100_supportFound
             if (function_exists('sapi_windows_vt100_support') && @sapi_windows_vt100_support(STDOUT)) {
                 return true;
             } elseif (getenv('ANSICON') !== false || getenv('ConEmuANSI') === 'ON') {
@@ -210,6 +212,7 @@ class ConsoleColor
             }
             return false;
         } else {
+            // phpcs:ignore Generic.PHP.NoSilencedErrors
             return function_exists('posix_isatty') && @posix_isatty(STDOUT);
         }
     }
@@ -222,6 +225,7 @@ class ConsoleColor
     public function are256ColorsSupported()
     {
         if (DIRECTORY_SEPARATOR === '\\') {
+            // phpcs:ignore Generic.PHP.NoSilencedErrors,PHPCompatibility.FunctionUse.NewFunctions.sapi_windows_vt100_supportFound
             return function_exists('sapi_windows_vt100_support') && @sapi_windows_vt100_support(STDOUT);
         } else {
             return strpos(getenv('TERM'), '256color') !== false;

--- a/src/InvalidStyleException.php
+++ b/src/InvalidStyleException.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpConsoleColor;
 
 class InvalidStyleException extends \Exception

--- a/tests/ConsoleColorTest.php
+++ b/tests/ConsoleColorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpConsoleColor\Test;
 
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
@@ -309,4 +310,3 @@ class ConsoleColorTest extends TestCase
         }
     }
 }
-

--- a/tests/Fixtures/ConsoleColorWithForceSupport.php
+++ b/tests/Fixtures/ConsoleColorWithForceSupport.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PHP_Parallel_Lint\PhpConsoleColor\Test\Fixtures;
 
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;


### PR DESCRIPTION
### PHPCS: use PHP-Code-Style 2.0

* Composer: require `php-parallel-lint/php-code-style` at 2.0 or higher.
* Composer: remove the requirement for PHPCS. This will now be inherited from the code style repo.
* GH Actions, test workflow: adjust the removal of the PHPCS dependency to match.

### Ruleset: various tweaks for PHP-Code-Style 2.0

* Scan all PHP files, not just the file in `src` for improved consistency across the code base, but exclude the `vendor` and the `build` (code coverage) directories.
* Enable parallel scanning for faster results.
* Use the ruleset from PHP-Code-Style by name.
* Set the `testVersion` for use with PHPCompatibility.
* Include minimal documentation in the ruleset.

### CS: various minor fixes

Fix up the issues which will be flagged by PHP-Code-Style 2.0 and explicitly ignore a couple of (non-)issues.

Includes no longer allowing warnings in the GH Actions build.