### PR TITLE
Changelog for the release of version 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+_Nothing yet._
+
+
+## [1.0.1] - 2021-12-21
+
+### Changed
+
+- Support for PHP 5.3 has been restored, [#22] from [@jrfnl].
+
 ### Internal
-- Travis: add build against PHP 8.0 [#12] from [@jrfnl].
-- PHPCS: various improvements [#13] from [@jrfnl].
-- PHPUnit: improve configuration [#14] from [@jrfnl].
-- PHPUnit: use annotations for fixtures / cross-version compat up to PHPUnit 9.x [#16] from [@jrfnl].
-- CI: switch to GH Actions [#17] from [@jrfnl].
-- GH Actions: set error reporting to E_ALL [#18] from [@jrfnl].
+- Welcome [@jrfnl] as new co-maintainer.
+- Improvements to the test suite, [#14], [#16], [#19], [#23], [#24] from [@jrfnl].
+- Improvements to the code consistency, [#13], [#23], [#25] from [@jrfnl].
+- Improvements to the CI/QA setup, [#12], [#17], [#18], [#20], [#27], [#28] from [@jrfnl].
+- Improvements to the changelog, [#21] from [@jrfnl].
 
 [#12]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/12
 [#13]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/13
@@ -20,6 +28,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 [#16]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/16
 [#17]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/17
 [#18]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/18
+[#19]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/19
+[#20]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/20
+[#21]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/21
+[#22]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/22
+[#23]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/23
+[#24]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/24
+[#25]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/25
+[#27]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/27
+[#28]: https://github.com/php-parallel-lint/PHP-Console-Color/pull/28
 
 
 ## [1.0] - 2020-10-31
@@ -65,7 +82,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Travis: only run PHPCS on PHP 7.4 from [@jrfnl].
 
 
-[Unreleased]: https://github.com/php-parallel-lint/PHP-Console-Color/compare/v1.0...HEAD
+[Unreleased]: https://github.com/php-parallel-lint/PHP-Console-Color/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/php-parallel-lint/PHP-Console-Color/compare/v1.0...v1.0.1
 [1.0]: https://github.com/php-parallel-lint/PHP-Console-Color/compare/v0.3...v1.0
 [0.3]: https://github.com/php-parallel-lint/PHP-Console-Color/compare/v0.2...v0.3
 


### PR DESCRIPTION
As of this release, I propose to be less detailed about internal changes, as those aren't that relevant to end-users anyway.

---

@grogy 

As far as I'm concerned, all pertinent technical debt in this repo has now been addressed. The only thing left to do would be to add a code coverage check to the GH Actions run with management via an external service.

In the mean time, I'd like to suggest tagging a new release, so Highlighter can get this version and then can also be made compatible with PHP 5.3 again.

With that in mind, I've pulled this changelog. Happy to do the release if you agree. I've set the release date in this PR (tentatively) at tomorrow.

Re: the version number - this could either be version 1.0.1 or 1.1.0 depending on whether or not "Adding back PHP 5.3 support" is seen as a new feature. What do you think ?