### PR TITLE
GH Actions: Added support for code coverage with Coveralls.io

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,34 @@ jobs:
 
       - name: Run unit tests
         run: composer phpunit
+
+  coverage:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          ini-values: zend.assertions=1, error_reporting=-1, display_errors=On
+          coverage: xdebug
+
+      - name: Install Composer dependencies - normal
+        uses: "ramsey/composer-install@v2"
+
+      - name: Run the unit tests with code coverage
+        run: composer coverage
+
+      - name: Install Coveralls
+        if: ${{ success() }}
+        run: composer require php-coveralls/php-coveralls:"^2.5.2" --no-interaction
+
+      - name: Upload coverage results to Coveralls
+        if: ${{ success() }}
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: vendor/bin/php-coveralls -v -x build/logs/clover.xml

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ PHP Console Color
 [![CS](https://github.com/php-parallel-lint/PHP-Console-Color/actions/workflows/cs.yml/badge.svg)](https://github.com/php-parallel-lint/PHP-Console-Color/actions/workflows/cs.yml)
 [![Test](https://github.com/php-parallel-lint/PHP-Console-Color/actions/workflows/test.yml/badge.svg)](https://github.com/php-parallel-lint/PHP-Console-Color/actions/workflows/test.yml)
 [![License](https://poser.pugx.org/php-parallel-lint/php-console-color/license.svg)](https://packagist.org/packages/php-parallel-lint/php-console-color)
+[![Coverage Status](https://coveralls.io/repos/github/php-parallel-lint/PHP-Console-Color/badge.svg?branch=coveralls)](https://coveralls.io/github/php-parallel-lint/PHP-Console-Color?branch=coveralls)
 
 Simple library for creating colored console ouput.
 


### PR DESCRIPTION
Code coverage is generated only in one PHP version - 7.4.

- current coverage 100%
- link to coveralls.io https://coveralls.io/github/php-parallel-lint/PHP-Console-Color 
- added badge
- resolve issue #29 