### PR TITLE
GH Actions: running tests on PHP 7.4 one time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,18 @@ jobs:
 
     strategy:
       matrix:
-        php: ['5.3', '5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
+        php:
+          - '5.3'
+          - '5.4'
+          - '5.5'
+          - '5.6'
+          - '7.0'
+          - '7.1'
+          - '7.2'
+          - '7.3'
+          # PHP 7.4 is tested in coverage section
+          - '8.0'
+          - '8.1'
         experimental: [false]
 
         include:


### PR DESCRIPTION
PHP 7.4 is tested again in code coverage part. Is not needed test it twice.

---

This MR solve issue #31

I mean the best solution is exactly say in comment why is 7.4 skipped