### PR TITLE
GH Actions: update PHP versions in workflows

### DIFF
--- a/.github/workflows/cs.yml
+++ b/.github/workflows/cs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: 'latest'
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,10 +30,11 @@ jobs:
           # PHP 7.4 is tested in coverage section
           - '8.0'
           - '8.1'
+          - '8.2'
         experimental: [false]
 
         include:
-          - php: '8.2'
+          - php: '8.3'
             experimental: true
 
     name: "Test on PHP ${{ matrix.php }}"


### PR DESCRIPTION
PHP 8.2 has been released today :tada: and the `setup-php` action has announced support for PHP 8.3, so adding PHP 8.3 to the matrix and no longer allowing PHP 8.2 to fail the build.

Builds against PHP 8.3 are still allowed to fail for now.

Includes minor tweak setting PHP to `latest` for tasks where the PHP version isn't that relevant.