### PR TITLE
GH Actions: update for php-coveralls 2.6.0 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,12 +104,13 @@ jobs:
       - name: Run the unit tests with code coverage
         run: composer coverage
 
+      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer require php-coveralls/php-coveralls:"^2.5.2" --no-interaction
+        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: vendor/bin/php-coveralls -v -x build/logs/clover.xml
+        run: php-coveralls -v -x build/logs/clover.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,10 +104,10 @@ jobs:
       - name: Run the unit tests with code coverage
         run: composer coverage
 
-      # Global install is used to prevent a conflict with the local composer.lock in PHP 8.0+.
+      # Global install is used to prevent a conflict with the local composer.lock.
       - name: Install Coveralls
         if: ${{ success() }}
-        run: composer global require php-coveralls/php-coveralls:"^2.5.3" --no-interaction
+        run: composer global require php-coveralls/php-coveralls:"^2.6.0" --no-interaction
 
       - name: Upload coverage results to Coveralls
         if: ${{ success() }}


### PR DESCRIPTION
### GH Actions: fix CI

Grrr....

When PHPUnit has been installed on a high PHP version, some of the dependencies of PHPUnit will now be installed in versions not compatible with PHP 7.4, which blocks the install of the Coveralls package.

Installing PHP Coveralls globally instead should fix it.

I just wish PHP Coveralls would finally release a version compatible with PHP >  8.0....

Includes updating the version constraint to reference the latest release of the package.

### GH Actions: update for php-coveralls 2.6.0 

_(my wish has been granted)_

PHP-Coveralls 2.6.0 has just been released, so let's start using that.

Ref:
* https://github.com/php-coveralls/php-coveralls/releases/tag/v2.6.0