### PR TITLE
Composer: give credit where credit is due

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,10 @@
         {
             "name": "Jakub Onderka",
             "email": "jakub.onderka@gmail.com"
+        },
+        {
+            "name" : "Contributors",
+            "homepage" : "https://github.com/php-parallel-lint/PHP-Console-Color/graphs/contributors"
         }
     ],
     "autoload": {


### PR DESCRIPTION
The Package author still only mentioned "Jakub Onderka", while in reality other contributors should get credit for the work they have put in.

This is a relatively simple way to provide better credits.