### PR TITLE
GH Actions: PHP 8.4 has been released

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,10 +32,11 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
         experimental: [false]
 
         include:
-          - php: '8.4'
+          - php: '8.5'
             experimental: true
 
     name: "Test on PHP ${{ matrix.php }}"


### PR DESCRIPTION
* Builds against PHP 8.4 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.5.

Ref: https://www.php.net/releases/8.4/en.php