### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,11 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
         experimental: [false]
 
         include:
-          - php: '8.5'
+          - php: '8.6'
             experimental: true
 
     name: "Test on PHP ${{ matrix.php }}"


### PR DESCRIPTION
... which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Add _allowed to fail_ build against PHP 8.6.